### PR TITLE
Fixed TypeScript declarations generation

### DIFF
--- a/aqu.config.json
+++ b/aqu.config.json
@@ -1,0 +1,8 @@
+{
+    "dtsBundleGeneratorOptions": {
+        "libraries": {
+            "importedLibraries": ["react"],
+            "allowedTypesLibraries": []
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
     "name": "reactive-popups",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "ISC",
             "dependencies": {
                 "tiny-invariant": "^1.2.0"


### PR DESCRIPTION
This PR:
* Fixes TypeScript declarations generation. "react" library was included via triple-slash reference. However, this method is not working properly for react library declarations. Replaced with standard import.