### PR TITLE
Update popup on props change if popup exists

### DIFF
--- a/src/hooks/usePopup.ts
+++ b/src/hooks/usePopup.ts
@@ -26,15 +26,16 @@ export const usePopup = <P, K extends keyof P>(
 
     const open = useCallback<OptionalParamFunction<Omit<P, K>, void>>(
         (omittedProps?: Omit<P, K>) => {
-            if (!getPopup(popupIdentifier.current)) {
-                const popup = new DefaultPopup(
-                    PopupComponent,
-                    { ...props, ...omittedProps } as P,
+            const popup =
+                getPopup(popupIdentifier.current) ??
+                new DefaultPopup(
+                    PopupComponent as ComponentType<{}>,
+                    {},
                     popupIdentifier.current
                 );
+            popup.setProps({ ...props, ...omittedProps });
 
-                mount(popup);
-            }
+            mount(popup!);
         },
         [PopupComponent, mount, props, getPopup]
     );

--- a/src/hooks/usePopup.ts
+++ b/src/hooks/usePopup.ts
@@ -17,7 +17,7 @@ export const usePopup = <P, K extends keyof P>(
     props: Pick<P, K>,
     group: PopupGroup
 ): UsePopupBag<P, K> => {
-    const { mount, close: closePopup, getPopup } = usePopupsContext();
+    const { mount, close: closePopup } = usePopupsContext();
 
     const popupIdentifier = useRef<PopupIdentifier>({
         id: uuid(),
@@ -26,18 +26,15 @@ export const usePopup = <P, K extends keyof P>(
 
     const open = useCallback<OptionalParamFunction<Omit<P, K>, void>>(
         (omittedProps?: Omit<P, K>) => {
-            const popup =
-                getPopup(popupIdentifier.current) ??
-                new DefaultPopup(
-                    PopupComponent as ComponentType<{}>,
-                    {},
-                    popupIdentifier.current
-                );
-            popup.setProps({ ...props, ...omittedProps });
+            const popup = new DefaultPopup(
+                PopupComponent as ComponentType<{}>,
+                { ...props, ...omittedProps },
+                popupIdentifier.current
+            );
 
             mount(popup);
         },
-        [PopupComponent, mount, props, getPopup]
+        [PopupComponent, mount, props]
     );
 
     const close = useCallback(() => {

--- a/src/hooks/usePopup.ts
+++ b/src/hooks/usePopup.ts
@@ -35,7 +35,7 @@ export const usePopup = <P, K extends keyof P>(
                 );
             popup.setProps({ ...props, ...omittedProps });
 
-            mount(popup!);
+            mount(popup);
         },
         [PopupComponent, mount, props, getPopup]
     );

--- a/src/types/Popup.ts
+++ b/src/types/Popup.ts
@@ -19,8 +19,4 @@ export abstract class Popup<P = {}> {
     ) => {
         this.close = close;
     };
-
-    public setProps = (props: P) => {
-        this.props = props;
-    };
 }

--- a/src/types/Popup.ts
+++ b/src/types/Popup.ts
@@ -19,4 +19,8 @@ export abstract class Popup<P = {}> {
     ) => {
         this.close = close;
     };
+
+    public setProps = (props: P) => {
+        this.props = props;
+    };
 }

--- a/test/hooks/usePopup.test.tsx
+++ b/test/hooks/usePopup.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, renderHook, screen } from '@testing-library/react';
+import { act, renderHook, screen } from '@testing-library/react';
 
 import { group, TestHookWrapper } from './TestHookWrapper';
 import { useCloseHandler } from '../../src/hooks/useCloseHandler';

--- a/test/hooks/usePopup.test.tsx
+++ b/test/hooks/usePopup.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, renderHook, screen } from '@testing-library/react';
+import { act, render, renderHook, screen } from '@testing-library/react';
 
 import { group, TestHookWrapper } from './TestHookWrapper';
 import { useCloseHandler } from '../../src/hooks/useCloseHandler';
@@ -12,6 +12,11 @@ const SimplePopupComponent: React.FC = jest.fn(() => {
 
     return <div>simple popup</div>;
 });
+
+const CustomizablePopupComponent: React.FC<{ message: string }> = jest.fn(
+    ({ message }) => <div>{message}</div>
+);
+
 const PopupComponentWithProps: React.FC<{
     prop1: number;
     prop2: string;
@@ -58,6 +63,30 @@ describe('usePopup', () => {
         });
 
         expect(() => screen.getByText('simple popup')).toThrow();
+    });
+
+    it('should update popup', () => {
+        const initialMessage = 'initial message';
+        const updatedMessage = 'updated message';
+
+        const { result } = renderHook(
+            () => usePopup(CustomizablePopupComponent, {}, group),
+            { wrapper: TestHookWrapper }
+        );
+
+        act(() => {
+            result.current[0]({ message: initialMessage });
+        });
+
+        expect(screen.getByText(initialMessage)).toBeDefined();
+
+        act(() => {
+            result.current[0]({ message: updatedMessage });
+        });
+
+        expect(screen.queryByText(initialMessage)).toBeNull();
+
+        expect(screen.getByText(updatedMessage)).toBeDefined();
     });
 
     it('should merge props', () => {


### PR DESCRIPTION
Currently calling open function returned by usePopup hook does not remount component, which does not allow to update content of popup without manually closing it.